### PR TITLE
Improve str2bool function

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+import pytest
+from whisper.utils import str2bool
+
+def test_str2bool_case_insensitive():
+    assert str2bool('True') is True
+    assert str2bool('true') is True
+    assert str2bool('FALSE') is False
+    assert str2bool('0') is False
+    assert str2bool('1') is True
+    assert str2bool('Yes') is True
+    assert str2bool('n') is False
+
+    with pytest.raises(ValueError):
+        str2bool('maybe')

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -27,11 +27,23 @@ def exact_div(x, y):
 
 
 def str2bool(string):
-    str2val = {"True": True, "False": False}
-    if string in str2val:
-        return str2val[string]
-    else:
-        raise ValueError(f"Expected one of {set(str2val.keys())}, got {string}")
+    """Parse a string into a boolean value."""
+
+    if isinstance(string, bool):
+        return string
+
+    str_lower = string.lower()
+    truthy = {"true", "t", "yes", "y", "1"}
+    falsy = {"false", "f", "no", "n", "0"}
+
+    if str_lower in truthy:
+        return True
+    if str_lower in falsy:
+        return False
+
+    raise ValueError(
+        f"Expected a boolean value (one of {truthy | falsy}), got {string}"
+    )
 
 
 def optional_int(string):


### PR DESCRIPTION
## Summary
- make `str2bool` accept more common true/false values
- add tests for updated parser

## Testing
- `pytest tests/test_utils.py -q`
- `pytest -k utils -q`


------
https://chatgpt.com/codex/tasks/task_e_683f3b506ec4832eb6270973a20f5f75